### PR TITLE
Switch to lazy storage of param removal code to save memory

### DIFF
--- a/src/data_driven_rate_equation_selection.jl
+++ b/src/data_driven_rate_equation_selection.jl
@@ -251,7 +251,8 @@ function calculate_all_parameter_removal_codes(param_names::Tuple{Symbol,Vararg{
             feasible_param_subset_codes = (feasible_param_subset_codes..., [0, 1])
         end
     end
-    return collect(Iterators.product(feasible_param_subset_codes...))
+    # return collect(Iterators.product(feasible_param_subset_codes...))
+    return Iterators.product(feasible_param_subset_codes...)
 end
 
 """

--- a/src/data_driven_rate_equation_selection.jl
+++ b/src/data_driven_rate_equation_selection.jl
@@ -48,7 +48,7 @@ function data_driven_rate_equation_selection(
     num_alpha_params = count(occursin.("alpha", string.([param_names...])))
     #check that range_number_params within bounds of minimal and maximal number of parameters
     @assert range_number_params[1] >=
-            length(param_names) - maximum([sum(x .> 0) for x in all_param_removal_codes]) "starting range_number_params cannot be below $(length(param_names) - maximum([sum(x .> 0) for x in all_param_removal_codes]))"
+            length(param_names) - length(param_removal_code_names) "starting range_number_params cannot be below $(length(param_names) - length(param_removal_code_names))"
     @assert range_number_params[2] <= length(param_names) "ending range_number_params cannot be above $(length(param_names))"
 
     if forward_model_selection

--- a/src/data_driven_rate_equation_selection.jl
+++ b/src/data_driven_rate_equation_selection.jl
@@ -51,7 +51,7 @@ function data_driven_rate_equation_selection(
             length(param_names) - length(param_removal_code_names) "starting range_number_params cannot be below $(length(param_names) - length(param_removal_code_names))"
     @assert range_number_params[2] <= length(param_names) "ending range_number_params cannot be above $(length(param_names))"
 
-    #TODO: maybe this can be sped up / simplified using filter(x -> sum(x .> 0) == range_number_params[2], all_params)
+    #TODO: simplify below from array comprehension synthax to filter(x -> sum(x .> 0) == range_number_params[2], all_params) and same for such code elsewhere
     if forward_model_selection
         num_param_range = (range_number_params[2]):-1:range_number_params[1]
         starting_param_removal_codes = [

--- a/src/data_driven_rate_equation_selection.jl
+++ b/src/data_driven_rate_equation_selection.jl
@@ -51,6 +51,7 @@ function data_driven_rate_equation_selection(
             length(param_names) - length(param_removal_code_names) "starting range_number_params cannot be below $(length(param_names) - length(param_removal_code_names))"
     @assert range_number_params[2] <= length(param_names) "ending range_number_params cannot be above $(length(param_names))"
 
+    #TODO: maybe this can be sped up / simplified using filter(x -> sum(x .> 0) == range_number_params[2], all_params)
     if forward_model_selection
         num_param_range = (range_number_params[2]):-1:range_number_params[1]
         starting_param_removal_codes = [


### PR DESCRIPTION
Changes the output of calculate_all_parameter_removal_codes() to return an iteration instead of array of tuples to save memory. E.g., for PKM2 enzyme with 6 substrates, products, and regulators that output was ~30GB vs ~0 with this change.