### PR TITLE
More efficient removal code calculations

### DIFF
--- a/test/tests_for_optimal_rate_eq_selection.jl
+++ b/test/tests_for_optimal_rate_eq_selection.jl
@@ -6,6 +6,8 @@ using DataDrivenEnzymeRateEqs, Test
 using CMAEvolutionStrategy, DataFrames, CSV, Statistics
 using BenchmarkTools
 
+#TODO: add a test for calculate_all_parameter_removal_codes_w_num_params()
+
 #test forward_selection_next_param_removal_codes
 num_metabolites = rand(4:8)
 n_alphas = rand(1:4)


### PR DESCRIPTION
Add `calculate_all_parameter_removal_codes_w_num_params()` function for more efficient calculation of all of the parameter removal codes with a given number of parameters and use it in place where previously list comprehension were used. The advantage is this implementation replaces calculations of slices of array for for loops, so it is dramatically faster (>>10x) and allocates less, which is important for MWC enzyme like PKM2 where a large fraction of calculation and memory was used by this operation that should not be a bottleneck as it is not actual optimization.