### PR TITLE
Upgrade reverse and forward_selection_next_param_removal_codes() to make them faster

### DIFF
--- a/src/data_driven_rate_equation_selection.jl
+++ b/src/data_driven_rate_equation_selection.jl
@@ -55,8 +55,10 @@ function data_driven_rate_equation_selection(
     end
 
     #calculate starting_param_removal_codes num_param_range[1] parameters
+    all_param_removal_codes = calculate_all_parameter_removal_codes(param_names)
     starting_param_removal_codes = calculate_all_parameter_removal_codes_w_num_params(
         num_param_range[1],
+        all_param_removal_codes,
         param_names,
         num_alpha_params,
     )
@@ -254,10 +256,10 @@ end
 """Generate codes for ways that params can be removed from the rate equation but still leave `num_params`"""
 function calculate_all_parameter_removal_codes_w_num_params(
     num_params,
+    all_param_removal_codes,
     param_names,
     num_alpha_params,
 )
-    all_param_removal_codes = calculate_all_parameter_removal_codes(param_names)
     codes_with_num_params = Tuple[]
     num_non_zero_in_each_code = Int[]
     for code in all_param_removal_codes

--- a/test/tests_for_optimal_rate_eq_selection.jl
+++ b/test/tests_for_optimal_rate_eq_selection.jl
@@ -11,7 +11,7 @@ using BenchmarkTools
 #test forward_selection_next_param_removal_codes
 num_metabolites = rand(4:8)
 n_alphas = rand(1:4)
-num_previous_step_params = rand((2 + num_metabolites):(3 + 2 * num_metabolites))
+num_previous_step_params = rand((2+num_metabolites):(3+2*num_metabolites))
 num_params = num_previous_step_params - 1
 param_names = (
     :L,
@@ -22,18 +22,18 @@ param_names = (
     [Symbol(:alpha, "_$(i)") for i in 1:n_alphas]...
 )
 param_removal_code_names = (
-        [
-            Symbol(replace(string(param_name), "_a" => "_allo")) for
-            param_name in param_names if
-            !contains(string(param_name), "_i") && param_name != :Vmax
-        ]...,
-    )
+    [
+        Symbol(replace(string(param_name), "_a_" => "_allo_", "Vmax_a" => "Vmax_allo")) for
+        param_name in param_names if
+        !contains(string(param_name), "_i") && param_name != :Vmax
+    ]...,
+)
 all_param_removal_codes = DataDrivenEnzymeRateEqs.calculate_all_parameter_removal_codes(param_names)
 param_subset_codes_with_num_params = [x
                                       for x in all_param_removal_codes
                                       if
                                       length(param_names) -
-                                      sum(values(x[1:(end - n_alphas)]) .> 0) - n_alphas ==
+                                      sum(values(x[1:(end-n_alphas)]) .> 0) - n_alphas ==
                                       num_previous_step_params]
 previous_param_removal_codes = [rand(param_subset_codes_with_num_params)
                                 for i in 1:rand(1:20)]
@@ -49,10 +49,10 @@ funct_output_param_subset_codes = [values(nt) for nt in nt_funct_output_param_su
 #ensure that funct_output_param_subset_codes have one less parameter than previous_param_removal_codes
 @test all(
     length(param_names) - n_alphas -
-    sum(funct_output_param_subset_code[1:(end - n_alphas)] .> 0) ==
+    sum(funct_output_param_subset_code[1:(end-n_alphas)] .> 0) ==
     (num_previous_step_params - 1)
-for
-funct_output_param_subset_code in funct_output_param_subset_codes
+    for
+    funct_output_param_subset_code in funct_output_param_subset_codes
 )
 #ensure that non-zero elements from previous_param_removal_codes are present in > 1 of the funct_output_param_subset_code but less than the max_matches
 count_matches = []
@@ -72,12 +72,12 @@ for funct_output_param_subset_code in funct_output_param_subset_codes
     count = 0
     max_matches_vect = Int[]
     for previous_param_removal_code in previous_param_removal_codes
-        count += funct_output_param_subset_code[1:(end - n_alphas)] .*
-                 previous_param_removal_code[1:(end - n_alphas)] ==
-                 previous_param_removal_code[1:(end - n_alphas)] .^ 2
+        count += funct_output_param_subset_code[1:(end-n_alphas)] .*
+                 previous_param_removal_code[1:(end-n_alphas)] ==
+                 previous_param_removal_code[1:(end-n_alphas)] .^ 2
         push!(max_matches_vect,
-            sum((previous_param_removal_code[1:(end - n_alphas)] .== 0) .*
-                non_zero_code_combos_per_param[1:(end - n_alphas)]))
+            sum((previous_param_removal_code[1:(end-n_alphas)] .== 0) .*
+                non_zero_code_combos_per_param[1:(end-n_alphas)]))
     end
     max_matches = maximum(max_matches_vect)
     push!(count_matches, max_matches >= count > 0)
@@ -98,12 +98,12 @@ param_names = (
     [Symbol(:alpha, "_$(i)") for i = 1:n_alphas]...,
 )
 param_removal_code_names = (
-        [
-            Symbol(replace(string(param_name), "_a_" => "_allo_")) for
-            param_name in param_names if
-            !contains(string(param_name), "_i") && param_name != :Vmax
-        ]...,
-    )
+    [
+        Symbol(replace(string(param_name), "_a_" => "_allo_")) for
+        param_name in param_names if
+        !contains(string(param_name), "_i") && param_name != :Vmax
+    ]...,
+)
 all_param_removal_codes = DataDrivenEnzymeRateEqs.calculate_all_parameter_removal_codes(param_names)
 param_subset_codes_with_num_params = [
     x for x in all_param_removal_codes if


### PR DESCRIPTION
`forward_selection_next_param_removal_codes()` and `reverse_selection_next_param_removal_codes()` would take hours to calculate its value for the first steps of optimization of an enzyme like PKM2, wasting cluster resources. The code was reimplemented to make the calculation run in < 5min.