### PR TITLE
modify qssa derivation to allow rate calculation wo products

### DIFF
--- a/src/qssa_general_rate_equation_derivation.jl
+++ b/src/qssa_general_rate_equation_derivation.jl
@@ -2787,14 +2787,18 @@ end
     Keq,
 )
     Vmax = 1.0
-    Vmax_rev =
+    Vmax_rev = ifelse(
+        !isinf(product_K_products),
         Vmax * (product_K_products)^num_products /
-        (Keq * (product_K_substrates)^num_substrates)
+        (Keq * (product_K_substrates)^num_substrates),
+        0.0,
+    )
     Rate =
         (
             Vmax * (S1 * S2 * S3 / (product_K_substrates)^num_substrates) -
             Vmax_rev * (P1 * P2 * P3 / (product_K_products)^num_products)
         ) / Z
+
     return Rate
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using SafeTestsets
     @safetestset "QSSA Rate Eq Derivation" begin
         include("tests_for_qssa_general_rate_eq_derivation.jl")
     end
-    @safetestset "MWC Rate Eq Fitting" begin
+    @safetestset "MWC and QSSA Rate Eq Fitting" begin
         include("tests_for_rate_eq_fitting.jl")
     end
     @safetestset "Plotting" begin


### PR DESCRIPTION
Previously Issa rate equation returned NaN in the absence of products due to K_product being Inf. This has now been fixed to corresponds to MWC derivation where this is handled with ifelse.