### PR TITLE
Prevent modifying nonidentifyable params in qssa equations search

### DIFF
--- a/src/data_driven_rate_equation_selection.jl
+++ b/src/data_driven_rate_equation_selection.jl
@@ -98,7 +98,11 @@ function data_driven_rate_equation_selection(
             (num_param_range[1]-1:-1:num_param_range[end]),
             (num_param_range[1]+1:+1:num_param_range[end]),
         )
-        if num_param_range[1] == num_param_range[end]
+        if ifelse(
+            forward_model_selection,
+            (num_param_range[1] < num_param_range[end]),
+            (num_param_range[1] > num_param_range[end]),
+        )
             @error "Could not find any fesible equations for this enzyme within range_number_params"
         end
         println("Trying new range_number_params: $num_param_range")
@@ -146,7 +150,7 @@ function data_driven_rate_equation_selection(
 
         if isempty(nt_param_removal_codes)
             println(
-                "Stop the search early as no feasible equations for this enzyme with $num_params parameters could be found.",
+                "Stoping the search early as no feasible equations for this enzyme with $num_params parameters could be found.",
             )
             break
         end
@@ -344,7 +348,7 @@ function find_practically_unidentifiable_params(
         if startswith(string(param_name), "K_") &&
            !startswith(string(param_name), "K_i") &&
            !startswith(string(param_name), "K_a") &&
-           length(split(string(param_name), "_")) > 3
+           length(split(string(param_name), "_")) >= 3
             if all([
                 prod(row) == 0 for
                 row in eachrow(data[:, Symbol.(split(string(param_name), "_")[2:end])])

--- a/src/data_driven_rate_equation_selection.jl
+++ b/src/data_driven_rate_equation_selection.jl
@@ -411,7 +411,7 @@ function calculate_all_parameter_removal_codes_w_num_params(
                 max_zero_alpha,
             )
     end
-    return filtered_nt_param_removal_codes_max_alpha
+    return unique(filtered_nt_param_removal_codes_max_alpha)
 end
 
 """
@@ -499,7 +499,11 @@ function forward_selection_next_param_removal_codes(
                 elseif startswith(string(param_removal_code_names[i]), "K_") &&
                        !startswith(string(param_removal_code_names[i]), "K_allo") &&
                        length(split(string(param_removal_code_names[i]), "_")) > 2
-                    feasible_param_subset_codes = [1, 2]
+                    if param_removal_code_names[i] in practically_unidentifiable_params
+                        feasible_param_subset_codes = [1]
+                    else
+                        feasible_param_subset_codes = [1, 2]
+                    end
                 end
                 for code_element in feasible_param_subset_codes
                     next_param_removal_code = collect(Int, previous_param_removal_code)
@@ -530,7 +534,7 @@ function forward_selection_next_param_removal_codes(
                 max_zero_alpha,
             )
     end
-    return filtered_nt_param_removal_codes_max_alpha
+    return unique(filtered_nt_param_removal_codes_max_alpha)
 end
 
 """
@@ -548,7 +552,9 @@ function reverse_selection_next_param_removal_codes(
     for previous_param_removal_code in nt_previous_param_removal_codes
         i_cut_off = length(previous_param_removal_code) - num_alpha_params
         for (i, code_element) in enumerate(previous_param_removal_code)
-            if i <= i_cut_off && code_element != 0
+            if i <= i_cut_off &&
+               code_element != 0 &&
+               param_removal_code_names[i] ∉ practically_unidentifiable_params
                 next_param_removal_code = collect(Int, previous_param_removal_code)
                 next_param_removal_code[i] = 0
                 push!(next_param_removal_codes, next_param_removal_code)
@@ -576,7 +582,7 @@ function reverse_selection_next_param_removal_codes(
                 max_zero_alpha,
             )
     end
-    return filtered_nt_param_removal_codes_max_alpha
+    return unique(filtered_nt_param_removal_codes_max_alpha)
 end
 
 """Filter removal codes to ensure that if K_S1 = Inf then all K_S1_S2 and all other K containing S1 in qssa cannot be 2, which stands for (K_S1_S2)^2 = K_S1 * K_S2"""

--- a/test/tests_for_optimal_rate_eq_selection.jl
+++ b/test/tests_for_optimal_rate_eq_selection.jl
@@ -1,5 +1,5 @@
-using TestEnv
-TestEnv.activate()
+# using TestEnv
+# TestEnv.activate()
 
 ##
 using DataDrivenEnzymeRateEqs, Test

--- a/test/tests_for_optimal_rate_eq_selection.jl
+++ b/test/tests_for_optimal_rate_eq_selection.jl
@@ -1,12 +1,10 @@
-# using TestEnv
-# TestEnv.activate()
+using TestEnv
+TestEnv.activate()
 
 ##
 using DataDrivenEnzymeRateEqs, Test
 using CMAEvolutionStrategy, DataFrames, CSV, Statistics
 using BenchmarkTools
-
-#TODO: add a test for calculate_all_parameter_removal_codes_w_num_params()
 
 #test forward_selection_next_param_removal_codes
 num_metabolites = rand(4:8)
@@ -544,11 +542,6 @@ reverse_selected_sym_rate_equation = display_rate_equation(
 )
 original_sym_rate_equation =
     display_rate_equation(qssa_data_gen_rate_equation, metab_names, data_gen_param_names)
-alrenative_original_sym_rate_equation = display_rate_equation(
-    qssa_alternative_data_gen_rate_equation,
-    metab_names,
-    data_gen_param_names,
-)
 
 println("Selected QSSA rate equation:")
 println(selected_sym_rate_equation)
@@ -563,7 +556,4 @@ forward_is_reverse =
 selected_is_original =
     simplify(original_sym_rate_equation - selected_sym_rate_equation) == 0
 selected_is_original = selected_is_original isa Bool ? selected_is_original : false
-selected_is_alternative =
-    simplify(alrenative_original_sym_rate_equation - selected_sym_rate_equation) == 0
-selected_is_alternative = selected_is_alternative isa Bool ? selected_is_alternative : false
-@test selected_is_original || selected_is_alternative
+@test selected_is_original


### PR DESCRIPTION
Previously the search algorythm could formet that some parameters are nonidentifyable based on data and start using them again which is wasteful. This is not prevented.