### PR TITLE
Fix Vmax treatment in MWC equations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataDrivenEnzymeRateEqs"
 uuid = "bf31c7e1-2152-4d3a-bc7a-576095d562b2"
 authors = ["Denis Titov titov@berkeley.edu and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 CMAEvolutionStrategy = "8d3b24bd-414e-49e0-94fb-163cc3a3e411"

--- a/src/mwc_general_rate_equation_derivation.jl
+++ b/src/mwc_general_rate_equation_derivation.jl
@@ -456,7 +456,6 @@ end
     Keq,
     n,
 )
-    Vmax_a = 1.0
     Vmax_a_rev = ifelse(
         !isinf(K_a_P1 * K_a_P2 * K_a_P3),
         Vmax_a * K_a_P1 * K_a_P2 * K_a_P3 / (Keq * K_a_S1 * K_a_S2 * K_a_S3),

--- a/test/tests_for_mwc_general_rate_eq_derivation_macro.jl
+++ b/test/tests_for_mwc_general_rate_eq_derivation_macro.jl
@@ -207,4 +207,4 @@ metabs_nt_second_reg = NamedTuple{metab_names}((
 ))
 rate_second_reg = rand_enz_rate_equation(metabs_nt_second_reg, params_nt, Keq)
 
-@test isapprox(rate_low_reg, rate_high_reg, rtol = 1e-6)
+@test isapprox(rate_first_reg, rate_second_reg, rtol = 1e-6)

--- a/test/tests_for_mwc_general_rate_eq_derivation_macro.jl
+++ b/test/tests_for_mwc_general_rate_eq_derivation_macro.jl
@@ -57,7 +57,7 @@ metabs_nt = NamedTuple{metab_names}((
 @test rand_enz_rate_equation(metabs_nt, params_nt, Keq) > 0.0
 
 #test Rate = Vmax_a when [Substrates] and [Activators] -> Inf and Vmax_a_rev when [Products] and [Activators] -> Inf
-Vmax_a = 1.0
+Vmax_a = rand()
 Vmax_i = rand()
 params_vec = []
 for param_name in propertynames(params_nt)
@@ -65,6 +65,10 @@ for param_name in propertynames(params_nt)
         push!(params_vec, 1e-3)
     elseif startswith(string(param_name), "alpha_")
         push!(params_vec, rand([0.0, 1.0]))
+    elseif param_name == :Vmax_a
+        push!(params_vec, Vmax_a)
+    elseif param_name == :Vmax_i
+        push!(params_vec, Vmax_i)
     else
         push!(params_vec, 1.0)
     end
@@ -100,12 +104,14 @@ rand_enz_rate_equation(metabs_nt, params_nt, Keq)
 @test isapprox(rand_enz_rate_equation(metabs_nt, params_nt, Keq), -Vmax_a_rev, rtol = 1e-2)
 
 #test Rate = Vmax_i when [Substrates] and [Allosteric Inhibitors] -> Inf and Vmax_i_rev when [Products] and [Allosteric Inhibitors] -> Inf
-Vmax_a = 1.0
+Vmax_a = rand()
 Vmax_i = rand()
 params_vec = []
 for param_name in propertynames(params_nt)
     if startswith(string(param_name), "K_i")
         push!(params_vec, 1e-3)
+    elseif param_name == :Vmax_a
+        push!(params_vec, Vmax_a)
     elseif param_name == :Vmax_i
         push!(params_vec, Vmax_i)
     elseif startswith(string(param_name), "alpha_")
@@ -144,8 +150,6 @@ metabs_nt = NamedTuple{metab_names}((
 @test isapprox(rand_enz_rate_equation(metabs_nt, params_nt, Keq), -Vmax_i_rev, rtol = 1e-2)
 
 #test Rate = 0 when [Inhibitors] -> Inf
-Vmax_a = 1.0
-Vmax_i = 1.0
 params_nt = NamedTuple{param_names}(rand(length(param_names)))
 metabs_nt = NamedTuple{metab_names}((
     rand(length(substrates))...,
@@ -155,3 +159,52 @@ metabs_nt = NamedTuple{metab_names}((
 ))
 rand_enz_rate_equation(metabs_nt, params_nt, Keq)
 @test isapprox(1.0 - rand_enz_rate_equation(metabs_nt, params_nt, Keq), 1.0, atol = 1e-2)
+
+#test Rate is unchanged regardless of regulators levels when Vmax_a = Vmax_i and Ka = Ki for all reactants
+Vmax_val = rand()
+params_vec = []
+# First pass: set all parameters with random values or Vmax_val
+for param_name in propertynames(params_nt)
+    if param_name == :Vmax_a || param_name == :Vmax_i
+        push!(params_vec, Vmax_val)
+    else
+        push!(params_vec, rand())
+    end
+end
+# Second pass: set Ki = Ka for substrates, products, and inhibitors only
+for (i, param_name) in enumerate(param_names)
+    if startswith(string(param_name), "K_i_")
+        metab_suffix = string(param_name)[5:end]
+        if metab_suffix[1] in ['S', 'P', 'I']  # not regulators
+            corresponding_Ka = Symbol("K_a_", metab_suffix)
+            Ka_index = findfirst(x -> x == corresponding_Ka, param_names)
+            if Ka_index !== nothing
+                params_vec[i] = params_vec[Ka_index]
+            end
+        end
+    end
+end
+params_nt = NamedTuple{param_names}(params_vec)
+
+# Test with one set of regulator concentrations
+substr_conc = rand(length(substrates))
+prod_conc = rand(length(products))
+inhib_conc = rand(length(inhibitors))
+metabs_nt_first_reg = NamedTuple{metab_names}((
+    substr_conc...,
+    prod_conc...,
+    inhib_conc...,
+    rand(length(regulators))...,
+))
+rate_first_reg = rand_enz_rate_equation(metabs_nt_first_reg, params_nt, Keq)
+
+# Test with second set of regulator concentrations
+metabs_nt_second_reg = NamedTuple{metab_names}((
+    substr_conc...,
+    prod_conc...,
+    inhib_conc...,
+    rand(length(regulators))...,
+))
+rate_second_reg = rand_enz_rate_equation(metabs_nt_second_reg, params_nt, Keq)
+
+@test isapprox(rate_low_reg, rate_high_reg, rtol = 1e-6)


### PR DESCRIPTION
For MWC equation generation the code erroneously allowed Vmax_a and Vmax_i to be different regardless of parameter removal code. This is now fixed and tests added.